### PR TITLE
Using hyphenated country name

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: workshop
 root: .
 venue: University of Nebraska-Lincoln
 address: Avery Hall, room 119
-country: USA
+country: United-States
 latlng: 40.819348, -96.704387
 humandate: Jan 08-09, 2015
 humantime: 8:30 am - 4:30 pm


### PR DESCRIPTION
Please use 'United-States' instead of 'USA' so that it picks up the flag icon on the main site.